### PR TITLE
Fixing serial number read to get from DB if it is populated

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -960,8 +960,16 @@ def version(verbose):
     asic_type = version_info['asic_type']
     asic_count = multi_asic.get_num_asics()
 
-    serial_number_cmd = "sudo decode-syseeprom -s"
-    serial_number = subprocess.Popen(serial_number_cmd, shell=True, text=True, stdout=subprocess.PIPE)
+    serial_number=''
+    db = SonicV2Connector()
+    db.connect(db.STATE_DB)
+    eeprom_table = db.get_all(db.STATE_DB, 'EEPROM_INFO|0x23')
+    if "Name" in eeprom_table and eeprom_table["Name"] == "Serial Number" and "Value" in eeprom_table:
+        serial_number = eeprom_table["Value"]
+
+    if not serial_number:
+        serial_number_cmd = "sudo decode-syseeprom -s"
+        serial_number = subprocess.Popen(serial_number_cmd, shell=True, text=True, stdout=subprocess.PIPE).stdout.read()
 
     sys_uptime_cmd = "uptime"
     sys_uptime = subprocess.Popen(sys_uptime_cmd, shell=True, text=True, stdout=subprocess.PIPE)
@@ -976,7 +984,7 @@ def version(verbose):
     click.echo("HwSKU: {}".format(hwsku))
     click.echo("ASIC: {}".format(asic_type))
     click.echo("ASIC Count: {}".format(asic_count))
-    click.echo("Serial Number: {}".format(serial_number.stdout.read().strip()))
+    click.echo("Serial Number: {}".format(serial_number.strip()))
     click.echo("Uptime: {}".format(sys_uptime.stdout.read().strip()))
     click.echo("\nDocker images:")
     cmd = 'sudo docker images --format "table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.Size}}"'


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Modified show version command to pick serial number from STATE_DB if it was populated instead of getting it from EEPROM.

#### How I did it
Check state_db to see if serial number EEPROM section is populated. If yes use the data from DB. If not, read it from the decode-syseeprom

#### How to verify it
Verify running 'show version' with and without pmon running to validate both scenarios, since eepromd in pmon populates the EEPROM table in state_db

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

