### PR TITLE
Db mig feture fix 202012

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -181,9 +181,10 @@ class DBMigrator():
         '''
         feature_table = self.configDB.get_table('FEATURE')
         for feature, config in feature_table.items():
-            state = config.pop('status', 'disabled')
-            config['state'] = state
-            self.configDB.set_entry('FEATURE', feature, config)
+            if 'status' in config:
+                state = config.pop('status', 'disabled')
+                config['state'] = state
+                self.configDB.set_entry('FEATURE', feature, config)
 
         container_feature_table = self.configDB.get_table('CONTAINER_FEATURE')
         for feature, config in container_feature_table.items():

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -181,9 +181,10 @@ class DBMigrator():
         '''
         feature_table = self.configDB.get_table('FEATURE')
         for feature, config in feature_table.items():
-            if 'status' in config:
-                state = config.pop('status', 'disabled')
+            state = config.get('status')
+            if state is not None:
                 config['state'] = state
+                config.pop('status')
                 self.configDB.set_entry('FEATURE', feature, config)
 
         container_feature_table = self.configDB.get_table('CONTAINER_FEATURE')

--- a/tests/db_migrator_input/config_db/feature-expected.json
+++ b/tests/db_migrator_input/config_db/feature-expected.json
@@ -7,6 +7,14 @@
 		"high_mem_alert": "disabled",
 		"state": "enabled"
 	},
+	"FEATURE|syncd": {
+		"auto_restart": "enabled",
+		"has_global_scope": "False",
+		"has_per_asic_scope": "True",
+		"has_timer": "False",
+		"high_mem_alert": "disabled",
+		"state": "enabled"
+	},
 	"FEATURE|telemetry": {
 		"auto_restart": "enabled",
 		"has_global_scope": "False",

--- a/tests/db_migrator_input/config_db/feature-input.json
+++ b/tests/db_migrator_input/config_db/feature-input.json
@@ -9,5 +9,8 @@
 	},
 	"FEATURE|telemetry": {
 		"status": "enabled"
+	},
+	"FEATURE|syncd": {
+		"state": "enabled"
 	}
 }

--- a/tests/db_migrator_input/init_cfg.json
+++ b/tests/db_migrator_input/init_cfg.json
@@ -8,6 +8,14 @@
 			"high_mem_alert": "disabled",
 			"state": "enabled"
 		},
+		"syncd": {
+			"auto_restart": "enabled",
+			"has_global_scope": "False",
+			"has_per_asic_scope": "True",
+			"has_timer": "False",
+			"high_mem_alert": "disabled",
+			"state": "enabled"
+		},
 		"telemetry": {
 			"auto_restart": "disabled",
 			"has_global_scope": "False",


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixing db_migrator.py for FEATURE table. In case of version_unknown, all versions' migrator APIs would be invoked which will also invoke the feature_table migration. Without the field check for 'status' the current logic will set it 'disabled' and will set 'state' field too to be 'disabled' which will in turn disable all the features bringing down the system.


#### How I did it
Added check to migrate only if 'status' field is present.


#### How to verify it
Install the image through onie and confirm if services are up


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

