### PR TITLE
[log_ssd_health]Fix log_ssd_health hang issue

### DIFF
--- a/scripts/log_ssd_health
+++ b/scripts/log_ssd_health
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-timeout 30 smartctl -a /dev/sda > /tmp/smartctl
+timeout --foreground 30 smartctl -a /dev/sda > /tmp/smartctl
 if [ -f /tmp/smartctl ];then
     logger -f /tmp/smartctl
 fi


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix log_ssd_health hang issue. The log_ssd_health command hangs due to timeout being used with docker exec -i which also affect warmboot flow.



#### How I did it
Added foreground option for timeout. This is recommended when not using the command on shell
https://man7.org/linux/man-pages/man1/timeout.1.html



#### How to verify it
Run log_ssd_health and verify it does not hang



#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

