### PR TITLE
[config reload]Fixing config reload when timer based delayed services are disabled

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -733,7 +733,9 @@ def _get_sonic_services():
 
 def _get_delayed_sonic_services():
     out = clicommon.run_command("systemctl list-dependencies --plain sonic-delayed.target | sed '1d'", return_cmd=True)
-    return (unit.strip().rstrip('.timer') for unit in out.splitlines())
+    timers = [unit for unit in out.splitlines() if(clicommon.run_command("systemctl is-enabled {}".format(unit),
+            return_cmd=True).strip() == "enabled")]
+    return (unit.strip().rstrip('.timer') for unit in timers)
 
 
 def _reset_failed_services():

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -66,6 +66,8 @@ def mock_run_command_side_effect(*args, **kwargs):
             return 'snmp.timer'
         elif command == "systemctl list-dependencies --plain sonic.target | sed '1d'":
             return 'swss'
+        elif command == "systemctl is-enabled snmp.timer":
+            return 'enabled'
         else:
             return ''
 
@@ -92,7 +94,7 @@ class TestLoadMinigraph(object):
             mock_run_command.assert_any_call('systemctl reset-failed swss')
             # Verify "systemctl reset-failed" is called for services under sonic-delayed.target 
             mock_run_command.assert_any_call('systemctl reset-failed snmp')
-            assert mock_run_command.call_count == 10
+            assert mock_run_command.call_count == 11
 
     def test_load_minigraph_with_port_config_bad_format(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(


### PR DESCRIPTION

Signed-off-by: Sudharsan Dhamal Gopalarathnam <sudharsand@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When timer based delayed services like mgmt-framework, telemetry and snmp are disabled and config reload is execute it fails Failed to reset failed state of unit mgmt-framework.service: Unit mgmt-framework.service not loaded.
The reason is these services don't get masked like regular services and these are derived from timers. So when reset-failed is tried on these services it leads to exception.

#### How I did it
When the feature related to these services are disabled their timers would be masked and wouldn't be "enabled". So when deriving the services from timers the services which are not enabled will be skipped.

#### How to verify it
Disable services like mgmt-framework, snmp and telemetry and execute config reload. The config reload should execute without failure

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

