### PR TITLE
Fixing get port speed when oper status is down

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -154,7 +154,8 @@ def port_oper_speed_get(db, intf_name):
     Get port oper speed
     """
     oper_speed = db.get(db.STATE_DB, PORT_STATE_TABLE_PREFIX + intf_name, PORT_SPEED)
-    if oper_speed is None or oper_speed == "N/A":
+    oper_status = db.get(db.APPL_DB, PORT_STATUS_TABLE_PREFIX + intf_name, PORT_OPER_STATUS)
+    if oper_speed is None or oper_speed == "N/A" or oper_status is None or oper_status != "up":
         return appl_db_port_status_get(db, intf_name, PORT_SPEED)
 
     return '{}G'.format(oper_speed[:-3])
@@ -164,7 +165,8 @@ def port_oper_speed_get_raw(db, intf_name):
     Get port raw speed. E.g. 100000, 50000 and so on.
     """
     speed = db.get(db.STATE_DB, PORT_STATE_TABLE_PREFIX + intf_name, PORT_SPEED)
-    if speed is None or speed == "N/A":
+    oper_status = db.get(db.APPL_DB, PORT_STATUS_TABLE_PREFIX + intf_name, PORT_OPER_STATUS)
+    if speed is None or speed == "N/A" or oper_status is None or oper_status != "up":
         speed = db.get(db.APPL_DB, PORT_STATUS_TABLE_PREFIX + intf_name, PORT_SPEED)
     return speed
 

--- a/scripts/portstat
+++ b/scripts/portstat
@@ -216,7 +216,8 @@ class Portstat(object):
         for ns in self.multi_asic.get_ns_list_based_on_options():
             self.db = multi_asic.connect_to_all_dbs_for_ns(ns)
             speed = self.db.get(self.db.STATE_DB, state_db_table_id, PORT_SPEED_FIELD)
-            if speed is None or speed == STATUS_NA:
+            oper_status = self.db.get(self.db.APPL_DB, app_db_table_id, PORT_OPER_STATUS_FIELD)
+            if speed is None or speed == STATUS_NA or oper_status is None or oper_status != "up":
                 speed = self.db.get(self.db.APPL_DB, app_db_table_id, PORT_SPEED_FIELD)
             if speed is not None:
                 return int(speed)

--- a/scripts/voqutil
+++ b/scripts/voqutil
@@ -38,6 +38,7 @@ SYSTEM_PORT_CORE = "core_index"
 SYSTEM_PORT_CORE_PORT = "core_port_index"
 SYSTEM_PORT_SPEED = "speed"
 SYSTEM_PORT_SWITCH_ID = "switch_id"
+SYSTEM_PORT_OPER_STATUS = "oper_status"
 
 SYSTEM_NEIGH_TABLE_PREFIX = swsscommon.CHASSIS_APP_SYSTEM_NEIGH_TABLE_NAME + "|"
 SYSTEM_NEIGH_MAC = "neigh"
@@ -116,7 +117,9 @@ def port_oper_speed_get(db, system_port_name):
     """
     full_table_id = SYSTEM_STATE_PORT_TABLE_PREFIX + system_port_name
     oper_speed = db.get(db.STATE_DB, full_table_id, SYSTEM_PORT_SPEED)
-    if oper_speed is None or oper_speed == "N/A":
+    oper_status = db.get(db.APPL_DB, SYSTEM_PORT_TABLE_PREFIX + system_port_name,
+                         SYSTEM_PORT_OPER_STATUS)
+    if oper_speed is None or oper_speed == "N/A" or oper_status is None or oper_status != "up":
         return appl_db_system_port_status_get(db, system_port_name, SYSTEM_PORT_SPEED)
 
     return '{}G'.format(oper_speed[:-3])

--- a/tests/dump_tests/dump_state_test.py
+++ b/tests/dump_tests/dump_state_test.py
@@ -34,6 +34,7 @@ table_display_output = '''\
 |             |           | | PORT_TABLE|Ethernet0 | +------------------+--------------------------+ | |
 |             |           | |                      | | field            | value                    | | |
 |             |           | |                      | |------------------+--------------------------| | |
+|             |           | |                      | | speed            | 100000                   | | |
 |             |           | |                      | | supported_speeds | 10000,25000,40000,100000 | | |
 |             |           | |                      | +------------------+--------------------------+ | |
 |             |           | +----------------------+-------------------------------------------------+ |
@@ -119,7 +120,7 @@ class TestDumpState(object):
         expected = {'Ethernet0': {'CONFIG_DB': {'keys': [{'PORT|Ethernet0': {'alias': 'etp1', 'description': 'etp1', 'index': '0', 'lanes': '25,26,27,28', 'mtu': '9100', 'pfc_asym': 'off', 'speed': '40000'}}], 'tables_not_found': []},
                                   'APPL_DB': {'keys': [{'PORT_TABLE:Ethernet0': {'index': '0', 'lanes': '0', 'alias': 'Ethernet0', 'description': 'ARISTA01T2:Ethernet1', 'speed': '25000', 'oper_status': 'down', 'pfc_asym': 'off', 'mtu': '9100', 'fec': 'rs', 'admin_status': 'up'}}], 'tables_not_found': []},
                                   'ASIC_DB': {'keys': [{'ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000056d': {'SAI_HOSTIF_ATTR_NAME': 'Ethernet0', 'SAI_HOSTIF_ATTR_OBJ_ID': 'oid:0x10000000004a4', 'SAI_HOSTIF_ATTR_OPER_STATUS': 'true', 'SAI_HOSTIF_ATTR_TYPE': 'SAI_HOSTIF_TYPE_NETDEV', 'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_STRIP'}}, {'ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000004a4': {'NULL': 'NULL', 'SAI_PORT_ATTR_ADMIN_STATE': 'true', 'SAI_PORT_ATTR_MTU': '9122', 'SAI_PORT_ATTR_SPEED': '100000'}}], 'tables_not_found': [], 'vidtorid': {'oid:0xd00000000056d': 'oid:0xd', 'oid:0x10000000004a4': 'oid:0x1690000000001'}},
-                                  'STATE_DB': {'keys': [{'PORT_TABLE|Ethernet0': {'supported_speeds': '10000,25000,40000,100000'}}], 'tables_not_found': []}}}
+                                  'STATE_DB': {'keys': [{'PORT_TABLE|Ethernet0': {'speed': '100000', 'supported_speeds': '10000,25000,40000,100000'}}], 'tables_not_found': []}}}
 
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         # Cause other tests depend and change these paths in the mock_db, this test would fail everytime when a field or a value in changed in this path, creating noise
@@ -136,7 +137,7 @@ class TestDumpState(object):
                     {"CONFIG_DB": {"keys": [{"PORT|Ethernet0": {"alias": "etp1", "description": "etp1", "index": "0", "lanes": "25,26,27,28", "mtu": "9100", "pfc_asym": "off", "speed": "40000"}}], "tables_not_found": []},
                      "APPL_DB": {"keys": [{"PORT_TABLE:Ethernet0": {"index": "0", "lanes": "0", "alias": "Ethernet0", "description": "ARISTA01T2:Ethernet1", "speed": "25000", "oper_status": "down", "pfc_asym": "off", "mtu": "9100", "fec": "rs", "admin_status": "up"}}], "tables_not_found": []},
                      "ASIC_DB": {"keys": [{"ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000056d": {"SAI_HOSTIF_ATTR_NAME": "Ethernet0", "SAI_HOSTIF_ATTR_OBJ_ID": "oid:0x10000000004a4", "SAI_HOSTIF_ATTR_OPER_STATUS": "true", "SAI_HOSTIF_ATTR_TYPE": "SAI_HOSTIF_TYPE_NETDEV", "SAI_HOSTIF_ATTR_VLAN_TAG": "SAI_HOSTIF_VLAN_TAG_STRIP"}}, {"ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000004a4": {"NULL": "NULL", "SAI_PORT_ATTR_ADMIN_STATE": "true", "SAI_PORT_ATTR_MTU": "9122", "SAI_PORT_ATTR_SPEED": "100000"}}], "tables_not_found": [], "vidtorid": {"oid:0xd00000000056d": "oid:0xd", "oid:0x10000000004a4": "oid:0x1690000000001"}},
-                     "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}},
+                     "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"speed": "100000", "supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}},
                     "Ethernet4":
                     {"CONFIG_DB": {"keys": [{"PORT|Ethernet4": {"admin_status": "up", "alias": "etp2", "description": "Servers0:eth0", "index": "1", "lanes": "29,30,31,32", "mtu": "9100", "pfc_asym": "off", "speed": "40000"}}], "tables_not_found": []},
                         "APPL_DB": {"keys": [], "tables_not_found": ["PORT_TABLE"]},
@@ -165,7 +166,7 @@ class TestDumpState(object):
         result = runner.invoke(dump.state, ["port", "Ethernet0", "--db", "ASIC_DB", "--db", "STATE_DB"])
         print(result.output)
         expected = {"Ethernet0": {"ASIC_DB": {"keys": [{"ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000056d": {"SAI_HOSTIF_ATTR_NAME": "Ethernet0", "SAI_HOSTIF_ATTR_OBJ_ID": "oid:0x10000000004a4", "SAI_HOSTIF_ATTR_OPER_STATUS": "true", "SAI_HOSTIF_ATTR_TYPE": "SAI_HOSTIF_TYPE_NETDEV", "SAI_HOSTIF_ATTR_VLAN_TAG": "SAI_HOSTIF_VLAN_TAG_STRIP"}}, {"ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x10000000004a4": {"NULL": "NULL", "SAI_PORT_ATTR_ADMIN_STATE": "true", "SAI_PORT_ATTR_MTU": "9122", "SAI_PORT_ATTR_SPEED": "100000"}}], "tables_not_found": [], "vidtorid": {"oid:0xd00000000056d": "oid:0xd", "oid:0x10000000004a4": "oid:0x1690000000001"}},
-                                  "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}}}
+                                  "STATE_DB": {"keys": [{"PORT_TABLE|Ethernet0": {"speed": "100000", "supported_speeds": "10000,25000,40000,100000"}}], "tables_not_found": []}}}
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         ddiff = compare_json_output(expected, result.output)
         assert not ddiff, ddiff

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -643,6 +643,7 @@
         "access": "False"
     },
     "PORT_TABLE|Ethernet0": {
+        "speed" : "100000",
         "supported_speeds": "10000,25000,40000,100000"
     },
     "PORT_TABLE|Ethernet112": {


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Recently enhancements update port oper speed in state_db and query it do display in show commands. However the oper speed gets updated only when admin is up. When admin goes down and if the user configures new speed it doesn't get updated in state_db. So a query to show interface status displays the last set port speed and not newly updated speed. 

#### How I did it
To overcome the issue, the port speed is read from state_db only when oper status is up. Else it is obtained from config_db.

#### How to verify it
Added test configuration to verify the scenario.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

