### PR TITLE
[portconfig]Allow config interface mtu only for physical ports

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -127,6 +127,9 @@ class portconfig(object):
         self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_FEC_CONFIG_FIELD_NAME: fec})
 
     def set_mtu(self, port, mtu):
+        port_tables = self.db.get_table(PORT_TABLE_NAME)
+        if port not in port_tables:
+            raise Exception("Invalid port %s" % (port))
         if self.verbose:
             print("Setting mtu %s on port %s" % (mtu, port))
         self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_MTU_CONFIG_FIELD_NAME: mtu})

--- a/tests/config_an_test.py
+++ b/tests/config_an_test.py
@@ -79,6 +79,11 @@ class TestConfigInterface(object):
         result = self.basic_check("advertised-types", ["Ethernet16", "Invalid"], ctx, operator.ne)
         assert "Setting RJ45 ports' advertised types is not supported" in result.output
 
+    def test_config_mtu(self, ctx):
+        self.basic_check("mtu", ["Ethernet0", "1514"], ctx)
+        result = self.basic_check("mtu", ["PortChannel0001", "1514"], ctx, operator.ne)
+        assert 'Invalid port PortChannel0001' in result.output
+
     def basic_check(self, command_name, para_list, ctx, op=operator.eq, expect_result=0):
         runner = CliRunner()
         result = runner.invoke(config.config.commands["interface"].commands[command_name], para_list, obj = ctx)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Allow config interface command to allow mtu only for physical ports. This has been the behavior until sometime back where a change made broke this and allowed the MTU to be passed to orchagent through port table which results in crash. 

May 13 12:04:12.494964 r-tigon-20 INFO swss#buffermgrd: :- handlePortTable: Port PortChannel101: MTU updated from  to 1514
May 13 12:04:12.495984 r-tigon-20 ERR swss#orchagent: :- set: switch id oid:0x0 doesn't exist
May 13 12:04:12.495984 r-tigon-20 ERR swss#orchagent: :- setPortMtu: Failed to set MTU 1536 to port pid:0, rv:-5
May 13 12:04:12.495984 r-tigon-20 ERR swss#orchagent: :- handleSaiSetStatus: Encountered failure in set operation, exiting orchagent, SAI API: SAI_API_PORT, status: SAI_STATUS


#### How I did it
Blocked MTU setting if the port is not physical port.

#### How to verify it
Added UT to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

