### PR TITLE
[subinterface]Fixing route add command to accept subinterface as dev

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4931,6 +4931,7 @@ def add_route(ctx, command_str):
         if (not route['ifname'] in config_db.get_keys('VLAN_INTERFACE') and
             not route['ifname'] in config_db.get_keys('INTERFACE') and
             not route['ifname'] in config_db.get_keys('PORTCHANNEL_INTERFACE') and
+            not route['ifname'] in config_db.get_keys('VLAN_SUB_INTERFACE') and
             not route['ifname'] == 'null'):
             ctx.fail('interface {} doesn`t exist'.format(route['ifname']))
 

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -8431,6 +8431,7 @@ This command is used to add a static route. Note that prefix /nexthop vrf`s and 
 
   ```
   admin@sonic:~$ config route add prefix 2.2.3.4/32 nexthop 30.0.0.9
+  admin@sonic:~$ config route add prefix 4.0.0.0/24 nexthop dev Ethernet32.10
   ```
 
 It also supports ECMP, and adding a new nexthop to the existing prefix will complement it and not overwrite them.

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -373,9 +373,15 @@
     "VLAN_SUB_INTERFACE|Ethernet0.10": {
         "admin_status": "up"
     },
+    "VLAN_SUB_INTERFACE|Ethernet0.10|10.11.12.13/24": {
+        "NULL" : "NULL"
+    },
     "VLAN_SUB_INTERFACE|Eth32.10": {
         "admin_status": "up",
         "vlan": "100"
+    },
+    "VLAN_SUB_INTERFACE|Eth32.10|32.10.11.12/24": {
+        "NULL" : "NULL"
     },
     "ACL_RULE|NULL_ROUTE_V4|DEFAULT_RULE": {
         "PACKET_ACTION": "DROP",

--- a/tests/static_routes_test.py
+++ b/tests/static_routes_test.py
@@ -372,6 +372,37 @@ class TestStaticRoutes(object):
         print(result.exit_code, result.output)
         assert not '14.2.3.4/32' in db.cfgdb.get_table('STATIC_ROUTE')
 
+    def test_static_route_nexthop_subinterface(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db':db.cfgdb}
+
+        # config route add prefix 2.2.3.5/32 nexthop dev Ethernet0.10
+        result = runner.invoke(config.config.commands["route"].commands["add"], \
+        ["prefix", "2.2.3.5/32", "nexthop", "dev", "Ethernet0.10"], obj=obj)
+        print(result.exit_code, result.output)
+        assert ('2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', '2.2.3.5/32') == {'nexthop': '', 'blackhole': 'false', 'distance': '0', 'ifname': 'Ethernet0.10', 'nexthop-vrf': ''}
+
+        # config route del prefix 2.2.3.5/32 nexthop dev Ethernet0.10
+        result = runner.invoke(config.config.commands["route"].commands["del"], \
+        ["prefix", "2.2.3.5/32", "nexthop", "dev", "Ethernet0.10"], obj=obj)
+        print(result.exit_code, result.output)
+        assert not ('2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
+
+        # config route add prefix 2.2.3.5/32 nexthop dev Eth32.10
+        result = runner.invoke(config.config.commands["route"].commands["add"], \
+        ["prefix", "2.2.3.5/32", "nexthop", "dev", "Eth32.10"], obj=obj)
+        print(result.exit_code, result.output)
+        assert ('2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
+        assert db.cfgdb.get_entry('STATIC_ROUTE', '2.2.3.5/32') == {'nexthop': '', 'blackhole': 'false', 'distance': '0', 'ifname': 'Eth32.10', 'nexthop-vrf': ''}
+
+        # config route del prefix 2.2.3.5/32 nexthop dev Eth32.10
+        result = runner.invoke(config.config.commands["route"].commands["del"], \
+        ["prefix", "2.2.3.5/32", "nexthop", "dev", "Eth32.10"], obj=obj)
+        print(result.exit_code, result.output)
+        assert not ('2.2.3.5/32') in db.cfgdb.get_table('STATIC_ROUTE')
+
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed route add command to accept subinterface as dev option. 

#### How I did it
Previously VLAN_SUB_INTERFACE table was not checked when validating the dev. Added that table to the list of tables to look.

#### How to verify it
Added UT to verify the change

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

