### PR TITLE
[subinterface]Avoid removing the subinterface when last configured ip is removed

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4156,7 +4156,8 @@ def remove(ctx, interface_name, ip_addr):
     remove_router_interface_ip_address(config_db, interface_name, ip_address)
     interface_addresses = get_interface_ipaddresses(config_db, interface_name)
     if len(interface_addresses) == 0 and is_interface_bind_to_vrf(config_db, interface_name) is False and get_intf_ipv6_link_local_mode(ctx, interface_name, table_name) != "enable":
-        config_db.set_entry(table_name, interface_name, None)
+        if table_name != "VLAN_SUB_INTERFACE":
+            config_db.set_entry(table_name, interface_name, None)
 
     if multi_asic.is_multi_asic():
         command = "sudo ip netns exec {} ip neigh flush dev {} {}".format(ctx.obj['namespace'], interface_name, str(ip_address))

--- a/tests/int_ip_input/config_db.json
+++ b/tests/int_ip_input/config_db.json
@@ -37,5 +37,11 @@
     },
     "VLAN_INTERFACE|Vlan2|192.168.1.1/21": {
         "NULL": "NULL"
+    },
+    "VLAN_SUB_INTERFACE|Ethernet16.16": {
+        "admin_status": "up"
+    },
+    "VLAN_SUB_INTERFACE|Ethernet16.16|16.1.1.1/16": {
+        "NULL": "NULL"
     }
 }


### PR DESCRIPTION
Signed-off-by: Sudharsan Dhamal Gopalarathnam <sudharsand@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Avoid removing the subinterface when last configured ip is removed
#### How I did it
In other interface types like INTERFACE, VLAN_INTERFACE, PORTCHANNEL_INTERFACE, when the last ip address is removed the CLI implicitly delete the interface table entry of type INTERFACE|intf_name. However this logic doesn't apply to VLAN_SUB_INTERFACE since the creation and removal will be controlled by config subinterface command

Without this fix the subinterface gets removed and show subinterface status will not list the subinterface.

#### How to verify it
Added UT to verify it.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

