### PR TITLE
[202012]VxLAN Tunnel Counters and Rates implementation

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -4,6 +4,7 @@ import click
 import ipaddress
 import json
 import syslog
+import operator
 
 import openconfig_acl
 import tabulate
@@ -754,7 +755,7 @@ class AclLoader(object):
                 namespace_configdb.mod_entry(self.ACL_RULE, key, None)
 
         for key in existing_controlplane_rules:
-            if cmp(self.rules_info[key], self.rules_db_info[key]) != 0:
+            if not operator.eq(self.rules_info[key], self.rules_db_info[key]):
                 self.configdb.set_entry(self.ACL_RULE, key, self.rules_info[key])
                 # Program for per-asic namespace corresponding to front asic also if present.
                 # For control plane ACL it's not needed but to keep all db in sync program everywhere

--- a/clear/main.py
+++ b/clear/main.py
@@ -203,6 +203,12 @@ def dhcp6relay_counters(interface):
 
 cli.add_command(dhcp6relay_counters)
 
+@cli.command()
+def tunnelcounters():
+    """Clear Tunnel counters"""
+    command = "tunnelstat -c"
+    run_command(command)
+
 #
 # 'clear watermarks
 #

--- a/config/vlan.py
+++ b/config/vlan.py
@@ -209,21 +209,13 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ip):
     if len(vlan) == 0:
         ctx.fail("{} doesn't exist".format(vlan_name))
 
-    # Verify all ip addresses are valid and not exist in DB
-    dhcp_servers = vlan.get('dhcp_servers', [])
-    dhcpv6_servers = vlan.get('dhcpv6_servers', [])
-
-    if dhcp_relay_destination_ip in dhcp_servers + dhcpv6_servers:
+    dhcp_relay_dests = vlan.get('dhcp_servers', [])
+    if dhcp_relay_destination_ip in dhcp_relay_dests:
         click.echo("{} is already a DHCP relay destination for {}".format(dhcp_relay_destination_ip, vlan_name))
         return
 
-    if clicommon.ipaddress_type(dhcp_relay_destination_ip) == 6:
-        dhcpv6_servers.append(dhcp_relay_destination_ip)
-        vlan['dhcpv6_servers'] = dhcpv6_servers
-    else:
-        dhcp_servers.append(dhcp_relay_destination_ip)
-        vlan['dhcp_servers'] = dhcp_servers
-
+    dhcp_relay_dests.append(dhcp_relay_destination_ip)
+    vlan['dhcp_servers'] = dhcp_relay_dests
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Added DHCP relay destination address {} to {}".format(dhcp_relay_destination_ip, vlan_name))
     try:
@@ -251,26 +243,15 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ip):
     if len(vlan) == 0:
         ctx.fail("{} doesn't exist".format(vlan_name))
 
-    # Remove dhcp servers if they exist in the DB
-    dhcp_servers = vlan.get('dhcp_servers', [])
-    dhcpv6_servers = vlan.get('dhcpv6_servers', [])
-
-    if not dhcp_relay_destination_ip in dhcp_servers + dhcpv6_servers:
+    dhcp_relay_dests = vlan.get('dhcp_servers', [])
+    if not dhcp_relay_destination_ip in dhcp_relay_dests:
         ctx.fail("{} is not a DHCP relay destination for {}".format(dhcp_relay_destination_ip, vlan_name))
 
-    if clicommon.ipaddress_type(dhcp_relay_destination_ip) == 6:
-        dhcpv6_servers.remove(dhcp_relay_destination_ip)
-        if len(dhcpv6_servers) == 0:
-            del vlan['dhcpv6_servers']
-        else:
-            vlan['dhcpv6_servers'] = dhcpv6_servers
+    dhcp_relay_dests.remove(dhcp_relay_destination_ip)
+    if len(dhcp_relay_dests) == 0:
+        del vlan['dhcp_servers']
     else:
-        dhcp_servers.remove(dhcp_relay_destination_ip)
-        if len(dhcp_servers) == 0:
-            del vlan['dhcp_servers']
-        else:
-            vlan['dhcp_servers'] = dhcp_servers
-    
+        vlan['dhcp_servers'] = dhcp_relay_dests
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Removed DHCP relay destination address {} from {}".format(dhcp_relay_destination_ip, vlan_name))
     try:

--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -241,6 +241,39 @@ def disable():
     configdb.mod_entry("FLEX_COUNTER_TABLE", "PG_WATERMARK", fc_info)
     configdb.mod_entry("FLEX_COUNTER_TABLE", BUFFER_POOL_WATERMARK, fc_info)
 
+# Tunnel counter commands
+@cli.group()
+def tunnel():
+    """ Tunnel counter commands """
+
+@tunnel.command()
+@click.argument('poll_interval', type=click.IntRange(100, 30000))
+def interval(poll_interval):
+    """ Set tunnel counter query interval """
+    configdb = ConfigDBConnector()
+    configdb.connect()
+    tunnel_info = {}
+    tunnel_info['POLL_INTERVAL'] = poll_interval
+    configdb.mod_entry("FLEX_COUNTER_TABLE", "TUNNEL", tunnel_info)
+
+@tunnel.command()
+def enable():
+    """ Enable tunnel counter query """
+    configdb = ConfigDBConnector()
+    configdb.connect()
+    tunnel_info = {}
+    tunnel_info['FLEX_COUNTER_STATUS'] = ENABLE
+    configdb.mod_entry("FLEX_COUNTER_TABLE", "TUNNEL", tunnel_info)
+
+@tunnel.command()
+def disable():
+    """ Disable tunnel counter query """
+    configdb = ConfigDBConnector()
+    configdb.connect()
+    tunnel_info = {}
+    tunnel_info['FLEX_COUNTER_STATUS'] = DISABLE
+    configdb.mod_entry("FLEX_COUNTER_TABLE", "TUNNEL", tunnel_info)
+
 @cli.command()
 def show():
     """ Show the counter configuration """
@@ -254,6 +287,7 @@ def show():
     pg_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'PG_WATERMARK')
     pg_drop_info = configdb.get_entry('FLEX_COUNTER_TABLE', PG_DROP)
     buffer_pool_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', BUFFER_POOL_WATERMARK)
+    tunnel_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'TUNNEL')
     
     header = ("Type", "Interval (in ms)", "Status")
     data = []
@@ -273,6 +307,8 @@ def show():
         data.append(['PG_DROP_STAT', pg_drop_info.get("POLL_INTERVAL", DEFLT_10_SEC), pg_drop_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if buffer_pool_wm_info:
         data.append(["BUFFER_POOL_WATERMARK_STAT", buffer_pool_wm_info.get("POLL_INTERVAL", DEFLT_60_SEC), buffer_pool_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+    if tunnel_info:
+        data.append(["TUNNEL_STAT", rif_info.get("POLL_INTERVAL", DEFLT_10_SEC), rif_info.get("FLEX_COUNTER_STATUS", DISABLE)])
 
     click.echo(tabulate(data, headers=header, tablefmt="simple", missingval=""))
 

--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -308,7 +308,7 @@ def show():
     if buffer_pool_wm_info:
         data.append(["BUFFER_POOL_WATERMARK_STAT", buffer_pool_wm_info.get("POLL_INTERVAL", DEFLT_60_SEC), buffer_pool_wm_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if tunnel_info:
-        data.append(["TUNNEL_STAT", rif_info.get("POLL_INTERVAL", DEFLT_10_SEC), rif_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+        data.append(["TUNNEL_STAT", tunnel_info.get("POLL_INTERVAL", DEFLT_10_SEC), tunnel_info.get("FLEX_COUNTER_STATUS", DISABLE)])
 
     click.echo(tabulate(data, headers=header, tablefmt="simple", missingval=""))
 

--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -250,7 +250,7 @@ def tunnel():
 @click.argument('poll_interval', type=click.IntRange(100, 30000))
 def interval(poll_interval):
     """ Set tunnel counter query interval """
-    configdb = ConfigDBConnector()
+    configdb = swsssdk.ConfigDBConnector()
     configdb.connect()
     tunnel_info = {}
     tunnel_info['POLL_INTERVAL'] = poll_interval
@@ -259,7 +259,7 @@ def interval(poll_interval):
 @tunnel.command()
 def enable():
     """ Enable tunnel counter query """
-    configdb = ConfigDBConnector()
+    configdb = swsssdk.ConfigDBConnector()
     configdb.connect()
     tunnel_info = {}
     tunnel_info['FLEX_COUNTER_STATUS'] = ENABLE
@@ -268,7 +268,7 @@ def enable():
 @tunnel.command()
 def disable():
     """ Disable tunnel counter query """
-    configdb = ConfigDBConnector()
+    configdb = swsssdk.ConfigDBConnector()
     configdb.connect()
     tunnel_info = {}
     tunnel_info['FLEX_COUNTER_STATUS'] = DISABLE

--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -413,6 +413,45 @@ def filter_out_vnet_routes(routes):
     return updated_routes
 
 
+def filter_out_standalone_tunnel_routes(routes):
+    config_db = swsscommon.ConfigDBConnector()
+    config_db.connect()
+    device_metadata = config_db.get_table('DEVICE_METADATA')
+    subtype = device_metadata['localhost'].get('subtype', '')
+
+    if subtype.lower() != 'dualtor':
+        return routes
+
+    app_db = swsscommon.DBConnector('APPL_DB', 0)
+    neigh_table = swsscommon.Table(app_db, 'NEIGH_TABLE')
+    neigh_keys = neigh_table.getKeys()
+    standalone_tunnel_route_ips = []
+    updated_routes = []
+
+    for neigh in neigh_keys:
+        _, mac = neigh_table.hget(neigh, 'neigh')
+        if mac == '00:00:00:00:00:00':
+            # remove preceding 'VlanXXXX' to get just the neighbor IP
+            neigh_ip = ':'.join(neigh.split(':')[1:])
+            standalone_tunnel_route_ips.append(neigh_ip)
+
+    if not standalone_tunnel_route_ips:
+        return routes
+
+    for route in routes:
+        ip, subnet = route.split('/')
+        ip_version = ipaddress.ip_address(ip).version
+
+        # we want to keep the route if it is not a standalone tunnel route.
+        # if the route subnet contains more than one address, it is not a
+        # standalone tunnel route
+        if (ip not in standalone_tunnel_route_ips) or \
+           ((ip_version == 6 and subnet != '128') or (ip_version == 4 and subnet != '32')):
+            updated_routes.append(route)
+
+    return updated_routes
+
+
 def check_routes():
     """
     The heart of this script which runs the checks.
@@ -449,6 +488,7 @@ def check_routes():
     _, rt_asic_miss = diff_sorted_lists(intf_appl, rt_asic_miss)
     rt_asic_miss = filter_out_default_routes(rt_asic_miss)
     rt_asic_miss = filter_out_vnet_routes(rt_asic_miss)
+    rt_asic_miss = filter_out_standalone_tunnel_routes(rt_asic_miss)
 
     # Check APPL-DB INTF_TABLE with ASIC table route entries
     intf_appl_miss, _ = diff_sorted_lists(intf_appl, rt_asic)

--- a/scripts/route_check_test.sh
+++ b/scripts/route_check_test.sh
@@ -2,22 +2,36 @@
 
 # add a route, interface & route-entry to simulate error
 #
-sonic-db-cli APPL_DB hmset "ROUTE_TABLE:20c0:d9b8:99:80::/64" "nexthop" "fc00::72,fc00::76,fc00::7a,fc00::7e" "ifname" "PortChannel01,PortChannel02,PortChannel03,PortChannel04"
+sonic-db-cli APPL_DB hmset "ROUTE_TABLE:20c0:d9b8:99:80::/64" "nexthop" "fc00::72,fc00::76,fc00::7a,fc00::7e" "ifname" "PortChannel01,PortChannel02,PortChannel03,PortChannel04" > /dev/null
+sonic-db-cli ASIC_DB hmset "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"192.193.120.255/25\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}" "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID" "oid:0x5000000000614" > /dev/null
+sonic-db-cli APPL_DB hmset  "INTF_TABLE:PortChannel01:10.0.0.99/31" "scope" "global" "family" "IPv4" > /dev/null
 
-
-sonic-db-cli ASIC_DB hmset "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"192.193.120.255/25\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}" "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID" "oid:0x5000000000614"
-
-sonic-db-cli APPL_DB hmset  "INTF_TABLE:PortChannel01:10.0.0.99/31" "scope" "global" "family" "IPv4"
-
-echo "expect errors!\n------\nRunning Route Check...\n"
+echo "------"
+echo "expect errors!"
+echo "Running Route Check..."
 ./route_check.py
 echo "return value: $?"
 
-sonic-db-cli APPL_DB del "ROUTE_TABLE:20c0:d9b8:99:80::/64"
-sonic-db-cli ASIC_DB del "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"192.193.120.255/25\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}"
-sonic-db-cli APPL_DB del "INTF_TABLE:PortChannel01:10.0.0.99/31"
+sonic-db-cli APPL_DB del "ROUTE_TABLE:20c0:d9b8:99:80::/64" > /dev/null
+sonic-db-cli ASIC_DB del "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"192.193.120.255/25\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}" > /dev/null
+sonic-db-cli APPL_DB del "INTF_TABLE:PortChannel01:10.0.0.99/31" > /dev/null
 
+# add standalone tunnel route to simulate unreachable neighbor scenario on dual ToR
+# in this scenario, we expect the route mismatch to be ignored
+sonic-db-cli APPL_DB hmset "NEIGH_TABLE:Vlan1000:fc02:1000::99" "neigh" "00:00:00:00:00:00" "family" "IPv6" > /dev/null
+sonic-db-cli ASIC_DB hmset 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"fc02:1000::99/128","switch_id":"oid:0x21000000000000","vr":"oid:0x300000000007c"}' "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID" "oid:0x400000000167d" "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION" "SAI_PACKET_ACTION_FORWARD" > /dev/null
 
-echo "expect success!\n------\nRunning Route Check...\n"
+echo "------"
+echo "expect success on dualtor, expect error on all other devices!"
+echo "Running Route Check..."
+./route_check.py
+echo "return value: $?"
+
+sonic-db-cli APPL_DB del "NEIGH_TABLE:Vlan1000:fc02:1000::99" > /dev/null
+sonic-db-cli ASIC_DB del 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"fc02:1000::99/128","switch_id":"oid:0x21000000000000","vr":"oid:0x300000000007c"}' > /dev/null
+
+echo "------"
+echo "expect success!"
+echo "Running Route Check..."
 ./route_check.py
 echo "return value: $?"

--- a/scripts/tunnelstat
+++ b/scripts/tunnelstat
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+
+#####################################################################
+#
+# tunnelstat is a tool for summarizing various tunnel statistics.
+#
+#####################################################################
+
+import _pickle as pickle
+import argparse
+import datetime
+import sys
+import os
+import sys
+import time
+
+# mock the redis for unit test purposes #
+try:
+    if os.environ["UTILITIES_UNIT_TESTING"] == "2":
+        modules_path = os.path.join(os.path.dirname(__file__), "..")
+        test_path = os.path.join(modules_path, "tests")
+        sys.path.insert(0, modules_path)
+        sys.path.insert(0, test_path)
+        import mock_tables.dbconnector
+except KeyError:
+    pass
+
+from collections import namedtuple, OrderedDict
+from natsort import natsorted
+from tabulate import tabulate
+from utilities_common.netstat import ns_diff, table_as_json, STATUS_NA, format_prate
+from swsscommon.swsscommon import SonicV2Connector
+
+
+nstat_fields = ("rx_b_ok", "rx_p_ok", "tx_b_ok", "tx_p_ok")
+NStats = namedtuple("NStats", nstat_fields)
+
+header = ['IFACE', 'RX_PKTS', 'RX_BYTES', 'RX_PPS','TX_PKTS', 'TX_BYTES', 'TX_PPS']
+
+rates_key_list = [ 'RX_BPS', 'RX_PPS', 'TX_BPS', 'TX_PPS']
+ratestat_fields = ("rx_bps", "rx_pps", "tx_bps", "tx_pps")
+RateStats = namedtuple("RateStats", ratestat_fields)
+
+
+counter_names = (
+    'SAI_TUNNEL_STAT_IN_OCTETS',
+    'SAI_TUNNEL_STAT_IN_PACKETS',
+    'SAI_TUNNEL_STAT_OUT_OCTETS',
+    'SAI_TUNNEL_STAT_OUT_PACKETS'
+)
+
+counter_types = {
+    "vxlan": "SAI_TUNNEL_TYPE_VXLAN"
+}
+
+COUNTER_TABLE_PREFIX = "COUNTERS:"
+RATES_TABLE_PREFIX = "RATES:"
+COUNTERS_TUNNEL_NAME_MAP = "COUNTERS_TUNNEL_NAME_MAP"
+COUNTERS_TUNNEL_TYPE_MAP = "COUNTERS_TUNNEL_TYPE_MAP"
+
+
+class Tunnelstat(object):
+    def __init__(self):
+        self.db = SonicV2Connector(use_unix_socket_path=False)
+        self.db.connect(self.db.COUNTERS_DB)
+        self.db.connect(self.db.APPL_DB)
+
+    def get_cnstat(self, tunnel=None, tun_type=None):
+        """
+            Get the counters info from database.
+        """
+        def get_counters(table_id):
+            """
+                Get the counters from specific table.
+            """
+            fields = [STATUS_NA] * (len(nstat_fields))
+            for pos, counter_name in enumerate(counter_names):
+                full_table_id = COUNTER_TABLE_PREFIX + table_id
+                counter_data =  self.db.get(self.db.COUNTERS_DB, full_table_id, counter_name)
+                if counter_data:
+                    fields[pos] = str(counter_data)
+            cntr = NStats._make(fields)
+            return cntr
+
+        def get_rates(table_id):
+            """
+                Get the rates from specific table.
+            """
+            fields = ["0","0","0","0"]
+            for pos, name in enumerate(rates_key_list):
+                full_table_id = RATES_TABLE_PREFIX + table_id
+                counter_data =  self.db.get(self.db.COUNTERS_DB, full_table_id, name)
+                if counter_data is None:
+                    fields[pos] = STATUS_NA
+                elif fields[pos] != STATUS_NA:
+                    fields[pos] = float(counter_data)
+            cntr = RateStats._make(fields)
+            return cntr
+
+        # Build a dictionary of the stats
+        cnstat_dict = OrderedDict()
+        ratestat_dict = OrderedDict()
+        cnstat_dict['time'] = datetime.datetime.now()
+
+        # Get the info from database
+        counter_tunnel_name_map = self.db.get_all(self.db.COUNTERS_DB, COUNTERS_TUNNEL_NAME_MAP)
+        counter_tunnel_type_map = self.db.get_all(self.db.COUNTERS_DB, COUNTERS_TUNNEL_TYPE_MAP)
+
+        if counter_tunnel_name_map is None:
+            print("No %s in the DB!" % COUNTERS_TUNNEL_NAME_MAP)
+            sys.exit(1)
+
+        if counter_tunnel_type_map is None:
+            print("No %s in the DB!" % COUNTERS_TUNNEL_TYPE_MAP)
+            sys.exit(1)  
+
+        if tun_type and tun_type not in counter_types:
+            print("Unknown tunnel type %s" % tun_type)
+            sys.exit(1)
+ 
+        if tunnel and not tunnel in counter_tunnel_name_map:
+            print("Interface %s missing from %s! Make sure it exists" % (tunnel, COUNTERS_TUNNEL_NAME_MAP))
+            sys.exit(2)
+
+        if tunnel:
+            if tun_type and counter_types[tun_type] != counter_tunnel_type_map[counter_tunnel_name_map[tunnel]]:
+                print("Mismtch in tunnel type. Requested type %s actual type %s" % (
+                      counter_types[tun_type], counter_tunnel_type_map[counter_tunnel_name_map[tunnel]]))
+                sys.exit(2)
+            cnstat_dict[tunnel] = get_counters(counter_tunnel_name_map[tunnel])
+            ratestat_dict[tunnel] = get_rates(counter_tunnel_name_map[tunnel])
+            return cnstat_dict, ratestat_dict
+
+        for tunnel in natsorted(counter_tunnel_name_map):
+            if not tun_type or counter_types[tun_type] == counter_tunnel_type_map[counter_tunnel_name_map[tunnel]]:
+                cnstat_dict[tunnel] = get_counters(counter_tunnel_name_map[tunnel])
+                ratestat_dict[tunnel] = get_rates(counter_tunnel_name_map[tunnel])
+        return cnstat_dict, ratestat_dict
+
+    def cnstat_print(self, cnstat_dict, ratestat_dict, use_json):
+        """
+            Print the cnstat.
+        """
+        table = []
+
+        for key, data in cnstat_dict.items():
+            if key == 'time':
+                continue
+
+            rates = ratestat_dict.get(key, RateStats._make([STATUS_NA] * len(rates_key_list)))
+            table.append((key, data.rx_p_ok, data.rx_b_ok, format_prate(rates.rx_pps),
+                               data.tx_p_ok, data.tx_b_ok, format_prate(rates.tx_pps)))
+
+        if use_json:
+            print(table_as_json(table, header))
+
+        else:
+            print(tabulate(table, header, tablefmt='simple', stralign='right'))
+
+    def cnstat_diff_print(self, cnstat_new_dict, cnstat_old_dict, ratestat_dict, use_json):
+        """
+            Print the difference between two cnstat results.
+        """
+
+        table = []
+
+        for key, cntr in cnstat_new_dict.items():
+            if key == 'time':
+                continue
+            old_cntr = None
+            if key in cnstat_old_dict:
+                old_cntr = cnstat_old_dict.get(key)
+
+            rates = ratestat_dict.get(key, RateStats._make([STATUS_NA] * len(rates_key_list)))
+            if old_cntr is not None:
+                table.append((key,
+                            ns_diff(cntr.rx_p_ok, old_cntr.rx_p_ok),
+                            ns_diff(cntr.rx_b_ok, old_cntr.rx_b_ok),
+                            format_prate(rates.rx_pps),
+                            ns_diff(cntr.tx_p_ok, old_cntr.tx_p_ok),
+                            ns_diff(cntr.tx_b_ok, old_cntr.tx_b_ok),
+                            format_prate(rates.tx_pps)))
+            else:
+                table.append((key,
+                            cntr.rx_p_ok,
+                            cntr.rx_b_ok,
+                            format_prate(rates.rx_pps),
+                            cntr.tx_p_ok,
+                            cntr.tx_b_ok,
+                            format_prate(rates.tx_pps)))
+        if use_json:
+            print(table_as_json(table, header))
+        else:
+            print(tabulate(table, header, tablefmt='simple', stralign='right'))
+
+    def cnstat_single_tunnel(self, tunnel, cnstat_new_dict, cnstat_old_dict):
+
+        header = tunnel + '\n' + '-'*len(tunnel)
+        body = """
+        RX:
+        %10s packets
+        %10s bytes
+        TX:
+        %10s packets
+        %10s bytes"""
+
+        cntr = cnstat_new_dict.get(tunnel)
+
+        if cnstat_old_dict:
+            old_cntr = cnstat_old_dict.get(tunnel)
+            if old_cntr:
+                body = body % (ns_diff(cntr.rx_p_ok, old_cntr.rx_p_ok),
+                            ns_diff(cntr.rx_b_ok, old_cntr.rx_b_ok),
+                            ns_diff(cntr.tx_p_ok, old_cntr.tx_p_ok),
+                            ns_diff(cntr.tx_b_ok, old_cntr.tx_b_ok))
+        else:
+            body = body % (cntr.rx_p_ok, cntr.rx_b_ok, cntr.tx_p_ok, cntr.tx_b_ok)
+
+        print(header)
+        print(body)
+
+
+def main():
+    parser  = argparse.ArgumentParser(description='Display the tunnels state and counters',
+                                        formatter_class=argparse.RawTextHelpFormatter,
+                                        epilog="""
+        Port state: (U)-Up (D)-Down (X)-Disabled
+        Examples:
+        tunnelstat -c -t test
+        tunnelstat -t test
+        tunnelstat -d -t test
+        tunnelstat
+        tunnelstat -p 20
+        tunnelstat -i Vlan1000
+        """)
+
+    parser.add_argument('-c', '--clear', action='store_true', help='Copy & clear stats')
+    parser.add_argument('-d', '--delete', action='store_true', help='Delete saved stats, either the uid or the specified tag')
+    parser.add_argument('-D', '--delete-all', action='store_true', help='Delete all saved stats')
+    parser.add_argument('-j', '--json', action='store_true', help='Display in JSON format')
+    parser.add_argument('-t', '--tag', type=str, help='Save stats with name TAG', default=None)
+    parser.add_argument('-i', '--tunnel', type=str, help='Show stats for a single tunnel', required=False)
+    parser.add_argument('-p', '--period', type=int, help='Display stats over a specified period (in seconds).', default=0)
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
+    parser.add_argument('-T', '--type', type=str, help ='Display Vxlan tunnel stats', required=False)
+    args = parser.parse_args()
+
+    save_fresh_stats = args.clear
+    delete_saved_stats = args.delete
+    delete_all_stats = args.delete_all
+    use_json = args.json
+    tag_name = args.tag if args.tag else ""
+    uid = str(os.getuid())
+    wait_time_in_seconds = args.period
+    tunnel_name = args.tunnel if args.tunnel else ""
+    tunnel_type = args.type if args.type else ""
+
+    # fancy filename with dashes: uid-tag-tunnel / uid-tunnel / uid-tag etc
+    filename_components = [uid, tag_name]
+    cnstat_file = "-".join(filter(None, filename_components))
+
+    cnstat_dir = "/tmp/tunnelstat-" + uid
+    cnstat_fqn_file = cnstat_dir + "/" + cnstat_file
+
+    if delete_all_stats:
+        # There is nothing to delete
+        if not os.path.isdir(cnstat_dir):
+            sys.exit(0)
+
+        for file in os.listdir(cnstat_dir):
+            os.remove(cnstat_dir + "/" + file)
+
+        try:
+            os.rmdir(cnstat_dir)
+            sys.exit(0)
+        except IOError as e:
+            print(e.errno, e)
+            sys.exit(e)
+
+    if delete_saved_stats:
+        try:
+            os.remove(cnstat_fqn_file)
+        except IOError as e:
+            if e.errno != ENOENT:
+                print(e.errno, e)
+                sys.exit(1)
+        finally:
+            if os.listdir(cnstat_dir) == []:
+                os.rmdir(cnstat_dir)
+            sys.exit(0)
+
+    tunnelstat = Tunnelstat()
+    cnstat_dict,ratestat_dict = tunnelstat.get_cnstat(tunnel=tunnel_name, tun_type=tunnel_type)
+
+    # At this point, either we'll create a file or open an existing one.
+    if not os.path.exists(cnstat_dir):
+        try:
+            os.makedirs(cnstat_dir)
+        except IOError as e:
+            print(e.errno, e)
+            sys.exit(1)
+
+    if save_fresh_stats:
+        try:
+            pickle.dump(cnstat_dict, open(cnstat_fqn_file, 'wb'))
+        except IOError as e:
+            sys.exit(e.errno)
+        else:
+            print("Cleared counters")
+            sys.exit(0)
+
+    if wait_time_in_seconds == 0:
+        if os.path.isfile(cnstat_fqn_file):
+            try:
+                cnstat_cached_dict = pickle.load(open(cnstat_fqn_file, 'rb'))
+                print("Last cached time was " + str(cnstat_cached_dict.get('time')))
+                if tunnel_name:
+                    tunnelstat.cnstat_single_tunnel(tunnel_name, cnstat_dict, cnstat_cached_dict)
+                else:
+                    tunnelstat.cnstat_diff_print(cnstat_dict, cnstat_cached_dict, ratestat_dict, use_json)
+            except IOError as e:
+                print(e.errno, e)
+        else:
+            if tag_name:
+                print("\nFile belonging to tag %s does not exist" % tag_name)
+                print("Did you run 'tunnelstat -c -t %s' to record the counters via tag %s?\n" % (tag_name, tag_name))
+            else:
+                if tunnel_name:
+                    tunnelstat.cnstat_single_tunnel(tunnel_name, cnstat_dict, None)
+                else:
+                    tunnelstat.cnstat_print(cnstat_dict, ratestat_dict, use_json)
+    else:
+        #wait for the specified time and then gather the new stats and output the difference.
+        time.sleep(wait_time_in_seconds)
+        cnstat_new_dict, ratestat_dict = tunnelstat.get_cnstat(tunnel=tunnel_name, tun_type=tunnel_type)
+        if tunnel_name:
+            tunnelstat.cnstat_single_tunnel(tunnel_name, cnstat_new_dict, cnstat_dict)
+        else:
+            tunnelstat.cnstat_diff_print(cnstat_new_dict, cnstat_dict, ratestat_dict, use_json)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tunnelstat
+++ b/scripts/tunnelstat
@@ -90,7 +90,7 @@ class Tunnelstat(object):
             for pos, name in enumerate(rates_key_list):
                 full_table_id = RATES_TABLE_PREFIX + table_id
                 counter_data =  self.db.get(self.db.COUNTERS_DB, full_table_id, name)
-                if counter_data is None:
+                if not counter_data:
                     fields[pos] = STATUS_NA
                 elif fields[pos] != STATUS_NA:
                     fields[pos] = float(counter_data)

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ setup(
         'scripts/storyteller',
         'scripts/syseeprom-to-json',
         'scripts/tempershow',
+        'scripts/tunnelstat',
         'scripts/update_json.py',
         'scripts/warm-reboot',
         'scripts/watermarkstat',

--- a/show/vlan.py
+++ b/show/vlan.py
@@ -32,10 +32,11 @@ def brief(db, verbose):
 
     # Parsing DHCP Helpers info
     for key in natsorted(list(vlan_dhcp_helper_data.keys())):
-        dhcp_helpers = vlan_dhcp_helper_data.get(key, {}).get("dhcp_servers", [])
-        dhcpv6_helpers = vlan_dhcp_helper_data.get(key, {}).get("dhcpv6_servers", [])
-        all_helpers = dhcp_helpers + dhcpv6_helpers
-        vlan_dhcp_helper_dict[key.strip('Vlan')] = all_helpers
+        try:
+            if vlan_dhcp_helper_data[key]['dhcp_servers']:
+                vlan_dhcp_helper_dict[key.strip('Vlan')] = vlan_dhcp_helper_data[key]['dhcp_servers']
+        except KeyError:
+            vlan_dhcp_helper_dict[key.strip('Vlan')] = " "
 
     # Parsing VLAN Gateway info
     for key in vlan_ip_data:

--- a/show/vxlan.py
+++ b/show/vxlan.py
@@ -306,3 +306,18 @@ def remotemac(remote_vtep_ip, count):
       output += ('%s \n' % (str(num)))
       click.echo(output)
 
+@vxlan.command()
+@click.argument('tunnel', required=False)
+@click.option('-p', '--period')
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+def counters(tunnel, period, verbose):
+    """Show VxLAN counters"""
+
+    cmd = "tunnelstat -T vxlan"
+    if period is not None:
+        cmd += " -p {}".format(period)
+    if tunnel is not None:
+        cmd += " -i {}".format(tunnel)
+
+    clicommon.run_command(cmd, display_cmd=verbose)
+

--- a/tests/acl_input/incremental_1.json
+++ b/tests/acl_input/incremental_1.json
@@ -1,0 +1,32 @@
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "ntp-acl": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "20.0.0.12/32"
+                                    }
+                                }, 
+                                "config": {
+                                    "sequence-id": 1
+                                }, 
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                }
+                            }
+                        }
+                    }, 
+                    "config": {
+                        "name": "ntp-acl"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/acl_input/incremental_2.json
+++ b/tests/acl_input/incremental_2.json
@@ -1,0 +1,32 @@
+{
+    "acl": {
+        "acl-sets": {
+            "acl-set": {
+                "ntp-acl": {
+                    "acl-entries": {
+                        "acl-entry": {
+                            "1": {
+                                "ip": {
+                                    "config": {
+                                        "source-ip-address": "20.0.0.12/32"
+                                    }
+                                }, 
+                                "config": {
+                                    "sequence-id": 1
+                                }, 
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "DROP"
+                                    }
+                                }
+                            }
+                        }
+                    }, 
+                    "config": {
+                        "name": "ntp-acl"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -27,6 +27,7 @@ PORT_BUFFER_DROP      60000               enable
 QUEUE_WATERMARK_STAT  default (60000)     enable
 PG_WATERMARK_STAT     default (60000)     enable
 PG_DROP_STAT          10000               enable
+TUNNEL_STAT           3000                enable
 """
 
 class TestCounterpoll(object):

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1525,6 +1525,10 @@
         "POLL_INTERVAL": "10000",
         "FLEX_COUNTER_STATUS": "enable"
     },
+    "FLEX_COUNTER_TABLE|TUNNEL": {
+        "POLL_INTERVAL": "3000",
+        "FLEX_COUNTER_STATUS": "enable"
+    },
     "PFC_WD|Ethernet0": {
         "action": "drop",
         "detection_time": "600",

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -498,7 +498,6 @@
     },
     "VLAN|Vlan1000": {
         "dhcp_servers@": "192.0.0.1,192.0.0.2,192.0.0.3,192.0.0.4",
-        "dhcpv6_servers@": "fc02:2000::1,fc02:2000::2",
         "vlanid": "1000"
     },
     "VLAN|Vlan2000": {
@@ -757,7 +756,8 @@
         "mac": "1d:34:db:16:a6:00",
         "platform": "x86_64-mlnx_msn3800-r0",
         "peer_switch": "sonic-switch",
-        "type": "ToRRouter"
+        "type": "ToRRouter",
+        "subtype": "DualToR"
     },
     "SNMP_COMMUNITY|msft": {
         "TYPE": "RO"

--- a/tests/mock_tables/counters_db.json
+++ b/tests/mock_tables/counters_db.json
@@ -121,6 +121,12 @@
             "TX_BPS": "0",
             "TX_PPS": "0"
     },
+    "COUNTERS:oid:0x2a0000000035e": {
+            "SAI_TUNNEL_STAT_IN_OCTETS": "81922",
+            "SAI_TUNNEL_STAT_IN_PACKETS": "452",
+            "SAI_TUNNEL_STAT_OUT_OCTETS": "23434",
+            "SAI_TUNNEL_STAT_OUT_PACKETS": "154"
+    },
     "COUNTERS_RIF_NAME_MAP": {
             "Ethernet20": "oid:0x600000000065f",
             "PortChannel0001": "oid:0x60000000005a1",
@@ -136,6 +142,18 @@
             "oid:0x600000000063c": "SAI_ROUTER_INTERFACE_TYPE_PORT",
             "oid:0x600000000063d": "SAI_ROUTER_INTERFACE_TYPE_PORT",
             "oid:0x600000000065f": "SAI_ROUTER_INTERFACE_TYPE_PORT"
+    },
+    "COUNTERS_TUNNEL_NAME_MAP": {
+            "vtep1": "oid:0x2a0000000035e"
+    },
+    "COUNTERS_TUNNEL_TYPE_MAP": {
+            "oid:0x2a0000000035e": "SAI_TUNNEL_TYPE_VXLAN"
+    },
+    "RATES:oid:0x2a0000000035e": {
+            "RX_BPS": "20971520",
+            "RX_PPS": "20523",
+            "TX_BPS": "2048",
+            "TX_PPS": "201"
     },
     "COUNTERS:DATAACL:DEFAULT_RULE": {
             "Bytes": "1",

--- a/tests/pgdropstat_test.py
+++ b/tests/pgdropstat_test.py
@@ -93,7 +93,7 @@ class TestPgDropstat(object):
         self.test_show_pg_drop_clear()
 
         # simulate 'config reload' to provoke counters recalculation (remove  backup from /tmp folder)
-        result = runner.invoke(config.config.commands["reload"], [ "--no_service_restart",  "-y"])
+        result = runner.invoke(config.config.commands["reload"], [ "--no_service_restart", "--disable_arp_cache",  "-y"])
 
         print(result.exit_code)
         print(result.output)

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -23,6 +23,7 @@ RESULT = "res"
 OP_SET = "SET"
 OP_DEL = "DEL"
 
+NEIGH_TABLE = 'NEIGH_TABLE'
 ROUTE_TABLE = 'ROUTE_TABLE'
 VNET_ROUTE_TABLE = 'VNET_ROUTE_TABLE'
 INTF_TABLE = 'INTF_TABLE'
@@ -217,6 +218,22 @@ test_data = {
         }
     },
     "6": {
+        DESCR: "dualtor standalone tunnel route case",
+        ARGS: "route_check",
+        PRE: {
+            APPL_DB: {
+                NEIGH_TABLE: {
+                    "Vlan1000:fc02:1000::99": { "neigh": "00:00:00:00:00:00", "family": "IPv6"}
+                }
+            },
+            ASIC_DB: {
+                RT_ENTRY_TABLE: {
+                    RT_ENTRY_KEY_PREFIX + "fc02:1000::99/128" + RT_ENTRY_KEY_SUFFIX: {},
+                }
+            }
+        }
+    },
+    "7": {
         DESCR: "Good one with VNET routes",
         ARGS: "route_check",
         PRE: {
@@ -335,6 +352,11 @@ class Table:
     def get(self, key):
         ret = copy.deepcopy(self.data.get(key, {}))
         return (True, ret)
+
+
+    def hget(self, key, field):
+        ret = copy.deepcopy(self.data.get(key, {}).get(field, {}))
+        return True, ret
 
 
 db_conns = {"APPL_DB": APPL_DB, "ASIC_DB": ASIC_DB}

--- a/tests/tunnelstat_test.py
+++ b/tests/tunnelstat_test.py
@@ -1,0 +1,108 @@
+import sys
+import os
+import traceback
+
+from click.testing import CliRunner
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "scripts")
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+import clear.main as clear
+import show.main as show
+from .mock_tables import dbconnector
+
+show_vxlan_counters_output = """\
+  IFACE    RX_PKTS    RX_BYTES      RX_PPS    TX_PKTS    TX_BYTES    TX_PPS
+-------  ---------  ----------  ----------  ---------  ----------  --------
+  vtep1        452       81922  20523.00/s        154       23434  201.00/s
+"""
+
+show_vxlan_counters_clear_output = """\
+  IFACE    RX_PKTS    RX_BYTES      RX_PPS    TX_PKTS    TX_BYTES    TX_PPS
+-------  ---------  ----------  ----------  ---------  ----------  --------
+  vtep1          0           0  20523.00/s          0           0  201.00/s
+"""
+
+show_vxlan_counters_interface_output = """\
+vtep1
+-----
+
+        RX:
+               452 packets
+             81922 bytes
+        TX:
+               154 packets
+             23434 bytes
+"""
+
+show_vxlan_counters_clear_interface_output = """\
+vtep1
+-----
+
+        RX:
+                 0 packets
+                 0 bytes
+        TX:
+                 0 packets
+                 0 bytes
+"""
+
+
+class TestTunnelstat(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["PATH"] += os.pathsep + scripts_path
+        os.environ["UTILITIES_UNIT_TESTING"] = "2"
+
+    def test_no_param(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["vxlan"].commands["counters"], [])
+        print(result.exit_code)
+        print(result.output)
+        traceback.print_tb(result.exc_info[2])
+        assert result.exit_code == 0
+        assert result.output == show_vxlan_counters_output
+
+    def test_single_tunnel(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["vxlan"].commands["counters"], ["vtep1"])
+        expected = show_vxlan_counters_interface_output
+        assert result.output == expected
+
+    def test_clear(self):
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands["tunnelcounters"], [])
+        print(result.stdout)
+        assert result.exit_code == 0
+        result = runner.invoke(show.cli.commands["vxlan"].commands["counters"], [])
+        print(result.stdout)
+        expected = show_vxlan_counters_clear_output
+
+        # remove the counters snapshot
+        show.run_command("tunnelstat -D")
+        for line in expected:
+            assert line in result.output
+
+    def test_clear_interface(self):
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands["tunnelcounters"], [])
+        print(result.stdout)
+        assert result.exit_code == 0
+        result = runner.invoke(show.cli.commands["vxlan"].commands["counters"], ["vtep1"])
+        print(result.stdout)
+        expected = show_vxlan_counters_clear_interface_output
+
+        # remove the counters snapshot
+        show.run_command("tunnelstat -D")
+        for line in expected:
+            assert line in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -16,8 +16,6 @@ show_vlan_brief_output="""\
 |           | fc02:1000::1/64 | Ethernet8       | untagged       | 192.0.0.2             |             |
 |           |                 | Ethernet12      | untagged       | 192.0.0.3             |             |
 |           |                 | Ethernet16      | untagged       | 192.0.0.4             |             |
-|           |                 |                 |                | fc02:2000::1          |             |
-|           |                 |                 |                | fc02:2000::2          |             |
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
 |      2000 | 192.168.0.10/21 | Ethernet24      | untagged       | 192.0.0.1             | enabled     |
 |           | fc02:1011::1/64 | Ethernet28      | untagged       | 192.0.0.2             |             |
@@ -38,8 +36,6 @@ show_vlan_brief_in_alias_mode_output="""\
 |           | fc02:1000::1/64 | etp3            | untagged       | 192.0.0.2             |             |
 |           |                 | etp4            | untagged       | 192.0.0.3             |             |
 |           |                 | etp5            | untagged       | 192.0.0.4             |             |
-|           |                 |                 |                | fc02:2000::1          |             |
-|           |                 |                 |                | fc02:2000::2          |             |
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
 |      2000 | 192.168.0.10/21 | etp7            | untagged       | 192.0.0.1             | enabled     |
 |           | fc02:1011::1/64 | etp8            | untagged       | 192.0.0.2             |             |
@@ -75,8 +71,7 @@ show_vlan_brief_with_portchannel_output="""\
 |           | fc02:1000::1/64 | Ethernet8       | untagged       | 192.0.0.2             |             |
 |           |                 | Ethernet12      | untagged       | 192.0.0.3             |             |
 |           |                 | Ethernet16      | untagged       | 192.0.0.4             |             |
-|           |                 | PortChannel1001 | untagged       | fc02:2000::1          |             |
-|           |                 |                 |                | fc02:2000::2          |             |
+|           |                 | PortChannel1001 | untagged       |                       |             |
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
 |      2000 | 192.168.0.10/21 | Ethernet24      | untagged       | 192.0.0.1             | enabled     |
 |           | fc02:1011::1/64 | Ethernet28      | untagged       | 192.0.0.2             |             |
@@ -125,16 +120,6 @@ Removed DHCP relay destination address 192.0.0.100 from Vlan1000
 Restarting DHCP relay service...
 """
 
-config_vlan_add_dhcp_relayv6_output="""\
-Added DHCP relay destination address fc02:2000::3 to Vlan1000
-Restarting DHCP relay service...
-"""
-
-config_vlan_del_dhcp_relayv6_output="""\
-Removed DHCP relay destination address fc02:2000::3 from Vlan1000
-Restarting DHCP relay service...
-"""
-
 show_vlan_brief_output_with_new_dhcp_relay_address="""\
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
 |   VLAN ID | IP Address      | Ports           | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
@@ -144,31 +129,6 @@ show_vlan_brief_output_with_new_dhcp_relay_address="""\
 |           |                 | Ethernet12      | untagged       | 192.0.0.3             |             |
 |           |                 | Ethernet16      | untagged       | 192.0.0.4             |             |
 |           |                 |                 |                | 192.0.0.100           |             |
-|           |                 |                 |                | fc02:2000::1          |             |
-|           |                 |                 |                | fc02:2000::2          |             |
-+-----------+-----------------+-----------------+----------------+-----------------------+-------------+
-|      2000 | 192.168.0.10/21 | Ethernet24      | untagged       | 192.0.0.1             | enabled     |
-|           | fc02:1011::1/64 | Ethernet28      | untagged       | 192.0.0.2             |             |
-|           |                 |                 |                | 192.0.0.3             |             |
-|           |                 |                 |                | 192.0.0.4             |             |
-+-----------+-----------------+-----------------+----------------+-----------------------+-------------+
-|      3000 |                 |                 |                |                       | disabled    |
-+-----------+-----------------+-----------------+----------------+-----------------------+-------------+
-|      4000 |                 | PortChannel1001 | tagged         |                       | disabled    |
-+-----------+-----------------+-----------------+----------------+-----------------------+-------------+
-"""
-
-show_vlan_brief_output_with_new_dhcp_relayv6_address="""\
-+-----------+-----------------+-----------------+----------------+-----------------------+-------------+
-|   VLAN ID | IP Address      | Ports           | Port Tagging   | DHCP Helper Address   | Proxy ARP   |
-+===========+=================+=================+================+=======================+=============+
-|      1000 | 192.168.0.1/21  | Ethernet4       | untagged       | 192.0.0.1             | disabled    |
-|           | fc02:1000::1/64 | Ethernet8       | untagged       | 192.0.0.2             |             |
-|           |                 | Ethernet12      | untagged       | 192.0.0.3             |             |
-|           |                 | Ethernet16      | untagged       | 192.0.0.4             |             |
-|           |                 |                 |                | fc02:2000::1          |             |
-|           |                 |                 |                | fc02:2000::2          |             |
-|           |                 |                 |                | fc02:2000::3          |             |
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
 |      2000 | 192.168.0.10/21 | Ethernet24      | untagged       | 192.0.0.1             | enabled     |
 |           | fc02:1011::1/64 | Ethernet28      | untagged       | 192.0.0.2             |             |
@@ -189,8 +149,6 @@ config_add_del_vlan_and_vlan_member_output="""\
 |           | fc02:1000::1/64 | Ethernet8       | untagged       | 192.0.0.2             |             |
 |           |                 | Ethernet12      | untagged       | 192.0.0.3             |             |
 |           |                 | Ethernet16      | untagged       | 192.0.0.4             |             |
-|           |                 |                 |                | fc02:2000::1          |             |
-|           |                 |                 |                | fc02:2000::2          |             |
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
 |      1001 |                 | Ethernet20      | untagged       |                       | disabled    |
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
@@ -213,8 +171,6 @@ config_add_del_vlan_and_vlan_member_in_alias_mode_output="""\
 |           | fc02:1000::1/64 | etp3            | untagged       | 192.0.0.2             |             |
 |           |                 | etp4            | untagged       | 192.0.0.3             |             |
 |           |                 | etp5            | untagged       | 192.0.0.4             |             |
-|           |                 |                 |                | fc02:2000::1          |             |
-|           |                 |                 |                | fc02:2000::2          |             |
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
 |      1001 |                 | etp6            | untagged       |                       | disabled    |
 +-----------+-----------------+-----------------+----------------+-----------------------+-------------+
@@ -579,19 +535,6 @@ class TestVlan(object):
             assert result.exit_code != 0
             assert "Error: 192.0.0.1000 is invalid IP address" in result.output
             assert mock_run_command.call_count == 0
-    
-    def test_config_vlan_add_dhcp_relay_with_invalid_ipv6(self):
-        runner = CliRunner()
-
-        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
-            result = runner.invoke(config.config.commands["vlan"].commands["dhcp_relay"].commands["add"],
-                                   ["1000", "fe80:2030:31:24"])
-            print(result.exit_code)
-            print(result.output)
-            # traceback.print_tb(result.exc_info[2])
-            assert result.exit_code != 0
-            assert "Error: fe80:2030:31:24 is invalid IP address" in result.output
-            assert mock_run_command.call_count == 0
 
     def test_config_vlan_add_dhcp_relay_with_invalid_ip_2(self):
         runner = CliRunner()
@@ -617,19 +560,6 @@ class TestVlan(object):
             # traceback.print_tb(result.exc_info[2])
             assert result.exit_code == 0
             assert "192.0.0.1 is already a DHCP relay destination for Vlan1000" in result.output
-            assert mock_run_command.call_count == 0
-    
-    def test_config_vlan_add_dhcp_relay_with_exist_ipv6(self):
-        runner = CliRunner()
-
-        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
-            result = runner.invoke(config.config.commands["vlan"].commands["dhcp_relay"].commands["add"],
-                                   ["1000", "fc02:2000::1"])
-            print(result.exit_code)
-            print(result.output)
-            # traceback.print_tb(result.exc_info[2])
-            assert result.exit_code == 0
-            assert "fc02:2000::1 is already a DHCP relay destination for Vlan1000" in result.output
             assert mock_run_command.call_count == 0
 
     def test_config_vlan_add_del_dhcp_relay_dest(self):
@@ -666,40 +596,6 @@ class TestVlan(object):
         print(result.output)
         assert result.output == show_vlan_brief_output
 
-    def test_config_vlan_add_del_dhcp_relayv6_dest(self):
-        runner = CliRunner()
-        db = Db()
-
-        # add new relay dest
-        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
-            result = runner.invoke(config.config.commands["vlan"].commands["dhcp_relay"].commands["add"],
-                                   ["1000", "fc02:2000::3"], obj=db)
-            print(result.exit_code)
-            print(result.output)
-            assert result.exit_code == 0
-            assert result.output == config_vlan_add_dhcp_relayv6_output
-            assert mock_run_command.call_count == 3
-
-        # show output
-        result = runner.invoke(show.cli.commands["vlan"].commands["brief"], [], obj=db)
-        print(result.output)
-        assert result.output == show_vlan_brief_output_with_new_dhcp_relayv6_address
-
-        # del relay dest
-        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
-            result = runner.invoke(config.config.commands["vlan"].commands["dhcp_relay"].commands["del"],
-                                   ["1000", "fc02:2000::3"], obj=db)
-            print(result.exit_code)
-            print(result.output)
-            assert result.exit_code == 0
-            assert result.output == config_vlan_del_dhcp_relayv6_output
-            assert mock_run_command.call_count == 3
-
-        # show output
-        result = runner.invoke(show.cli.commands["vlan"].commands["brief"], [], obj=db)
-        print(result.output)
-        assert result.output == show_vlan_brief_output
-
     def test_config_vlan_remove_nonexist_dhcp_relay_dest(self):
         runner = CliRunner()
 
@@ -711,19 +607,6 @@ class TestVlan(object):
             # traceback.print_tb(result.exc_info[2])
             assert result.exit_code != 0
             assert "Error: 192.0.0.100 is not a DHCP relay destination for Vlan1000" in result.output
-            assert mock_run_command.call_count == 0
-    
-    def test_config_vlan_remove_nonexist_dhcp_relayv6_dest(self):
-        runner = CliRunner()
-
-        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
-            result = runner.invoke(config.config.commands["vlan"].commands["dhcp_relay"].commands["del"],
-                                   ["1000", "fc02:2000::3"])
-            print(result.exit_code)
-            print(result.output)
-            # traceback.print_tb(result.exc_info[2])
-            assert result.exit_code != 0
-            assert "Error: fc02:2000::3 is not a DHCP relay destination for Vlan1000" in result.output
             assert mock_run_command.call_count == 0
 
     def test_config_vlan_remove_dhcp_relay_dest_with_nonexist_vlanid(self):

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -6,7 +6,6 @@ import sys
 
 import click
 import json
-import netaddr
 
 from natsort import natsorted
 from sonic_py_common import multi_asic
@@ -191,6 +190,7 @@ def get_interface_naming_mode():
 
 def is_ipaddress(val):
     """ Validate if an entry is a valid IP """
+    import netaddr
     if not val:
         return False
     try:
@@ -199,17 +199,6 @@ def is_ipaddress(val):
         return False
     return True
 
-def ipaddress_type(val):
-    """ Return the IP address type """
-    if not val:
-        return None
-
-    try:
-        ip_version = netaddr.IPAddress(str(val))
-    except netaddr.core.AddrFormatError:
-        return None
-
-    return ip_version.version
 
 def is_ip_prefix_in_key(key):
     '''


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Implemented Vxlan counters and rates. Defined show commands for counters and rates similar to port and tunnel rates.


#### How I did it
Implemented tunnelstat utility and used it in show vxlan counters command.


#### How to verify it
Using unit tests in CLI


#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

```
show vxlan counters
    IFACE    RX_PKTS    RX_BYTES    RX_PPS    TX_PKTS    TX_BYTES    TX_PPS
---------  ---------  ----------  --------  ---------  ----------  --------
vtep_1336      2,359         N/A    0.99/s    205,972         N/A   86.93/s

show vxlan counters  vtep_1336
vtep_1336
---------

        RX:
                13 packets
               N/A bytes
        TX:
             1,164 packets
               N/A bytes
```
