### PR TITLE
[fast-reboot]Avoid stopping masked services during fast-reboot

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -689,6 +689,12 @@ else
 fi
 
 for service in ${SERVICES_TO_STOP}; do
+    # Skip the masked services
+    state=$(systemctl is-enabled ${service})
+    if [[ $state == "masked" ]]; then
+        continue
+    fi
+
     debug "Stopping ${service} ..."
 
     # TODO: These exceptions for nat, sflow, lldp


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
During fast-reboot there were warnings for few services
sudo fast-reboot
Warning: The unit file, source configuration file or drop-ins of mux.service changed on disk. Run 'systemctl daemon-reload' to reload units.
Dumping conntrack entries failed
Warning: The unit file, source configuration file or drop-ins of nat.service changed on disk. Run 'systemctl daemon-reload' to reload units.
Warning: The unit file, source configuration file or drop-ins of sflow.service changed on disk. Run 'systemctl daemon-reload' to reload units.
Warning: Stopping docker.service, but it can still be activated by:
  docker.socket
Watchdog armed for 180 seconds

This is due to the fact that the services are masked and trying to stop them will throw warning

systemctl is-enabled sflow.service
masked
systemctl stop sflow.service
Warning: The unit file, source configuration file or drop-ins of sflow.service changed on disk. Run 'systemctl daemon-reload' to reload units.


#### How I did it
Added check to skip stopping the services in fast-reboot if the services are masked.

#### How to verify it
Execute fast-reboot with the fix and verify.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

