### PR TITLE
[config]Block adding IP address on portchannel member

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4374,6 +4374,12 @@ def add(ctx, interface_name, ip_addr, gw):
         click.echo("Interface {} is a member of vlan\nAborting!".format(interface_name))
         return
 
+    portchannel_member_table = config_db.get_table('PORTCHANNEL_MEMBER')
+
+    if interface_is_in_portchannel(portchannel_member_table, interface_name):
+        ctx.fail("{} is configured as a member of portchannel."
+                .format(interface_name))
+
     try:
         ip_address = ipaddress.ip_interface(ip_addr)
     except ValueError as err:

--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -111,6 +111,18 @@ class TestConfigIP(object):
         assert result.exit_code != 0
         assert ERROR_MSG in result.output
 
+    def test_ip_add_on_interface_which_is_member_of_portchannel(self):
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+
+        # config int ip add Ethernet32 100.10.10.1/24
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Ethernet32", "100.10.10.1/24"], obj=obj)
+        assert result.exit_code != 0
+        print(result.output)
+        print(result.exit_code)
+        assert 'Error: Ethernet32 is configured as a member of portchannel.' in result.output
+
     '''  Tests for IPv6 '''
 
     def test_add_del_interface_valid_ipv6(self):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added a check in config interface ip command to block if the interface is portchannel member

#### How I did it
Added check in config handling

#### How to verify it
Added UT to verify.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

