### PR TITLE
[show]Fix show route return code on error

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,8 +145,12 @@ def setup_single_bgp_instance_chassis(request):
         bgp_mocked_json = os.path.join(
             test_path, 'mock_tables', 'ipv6_bgp_summary_chassis.json')
 
+    _old_run_bgp_command = bgp_util.run_bgp_command
     bgp_util.run_bgp_command = mock.MagicMock(
         return_value=mock_show_bgp_summary("", ""))
+
+    yield
+    bgp_util.run_bgp_command = _old_run_bgp_command
 
 
 @pytest.fixture
@@ -213,6 +217,7 @@ def setup_single_bgp_instance(request):
         else:
             return ""
 
+    _old_run_bgp_command = bgp_util.run_bgp_command
     if any ([request.param == 'ip_route',\
              request.param == 'ip_specific_route', request.param == 'ip_special_route',\
              request.param == 'ipv6_route', request.param == 'ipv6_specific_route']):
@@ -230,7 +235,6 @@ def setup_single_bgp_instance(request):
         bgp_util.run_bgp_command = mock.MagicMock(
             return_value=mock_show_bgp_network_single_asic(request))
     elif request.param == 'ip_route_for_int_ip':
-        _old_run_bgp_command = bgp_util.run_bgp_command
         bgp_util.run_bgp_command = mock_run_bgp_command_for_static
     elif request.param == "show_bgp_summary_no_neigh":
         bgp_util.run_bgp_command = mock.MagicMock(
@@ -241,8 +245,7 @@ def setup_single_bgp_instance(request):
 
     yield
 
-    if request.param == 'ip_route_for_int_ip':
-        bgp_util.run_bgp_command = _old_run_bgp_command
+    bgp_util.run_bgp_command = _old_run_bgp_command
 
 
 @pytest.fixture

--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 import config.main as config
 import show.main as show
 from utilities_common.db import Db
+import utilities_common.bgp_util as bgp_util
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 ip_config_input_path = os.path.join(test_path, "ip_config_input")
@@ -30,12 +31,19 @@ Error: VRF mgmt does not exist!
 """
 
 class TestConfigIP(object):
+    _old_run_bgp_command = None
     @classmethod
     def setup_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "1"
+        cls._old_run_bgp_command = bgp_util.run_bgp_command
+        bgp_util.run_bgp_command = mock.MagicMock(
+            return_value=cls.mock_run_bgp_command())
         print("SETUP")
 
     ''' Tests for IPv4  '''
+
+    def mock_run_bgp_command():
+        return ""
 
     def test_add_del_interface_valid_ipv4(self):
         db = Db()
@@ -272,4 +280,5 @@ class TestConfigIP(object):
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        bgp_util.run_bgp_command = cls._old_run_bgp_command
         print("TEARDOWN")

--- a/tests/ip_show_routes_test.py
+++ b/tests/ip_show_routes_test.py
@@ -3,6 +3,7 @@ import pytest
 
 from . import show_ip_route_common
 from click.testing import CliRunner
+import mock
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -18,6 +19,26 @@ class TestShowIpRouteCommands(object):
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
         os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
         import mock_tables.dbconnector
+
+    def test_show_ip_route_err(
+            self,
+            setup_ip_route_commands):
+        show = setup_ip_route_commands
+
+        def mock_run_bgp_command(*args, **kwargs):
+            command = args[0]
+            print("% Unknown command: show ip route unknown")
+            return 1
+
+        with mock.patch('utilities_common.cli.run_command', mock.MagicMock(side_effect=mock_run_bgp_command)) as mock_run_command:
+            runner = CliRunner()
+            result = runner.invoke(
+                show.cli.commands["ip"].commands["route"], ["unknown"])
+            print("{}".format(result.output))
+            print(result.exit_code)
+            assert result.exit_code == 1
+            assert result.output == "% Unknown command: show ip route unknown" + "\n"
+
     @pytest.mark.parametrize('setup_single_bgp_instance',
                              ['ip_route'], indirect=['setup_single_bgp_instance'])
     def test_show_ip_route(
@@ -117,3 +138,4 @@ class TestShowIpRouteCommands(object):
         print("{}".format(result.output))
         assert result.exit_code == 0
         assert result.output == show_ip_route_common.show_ipv6_route_err_expected_output + "\n"
+

--- a/tests/ip_show_routes_test.py
+++ b/tests/ip_show_routes_test.py
@@ -4,10 +4,13 @@ import pytest
 from . import show_ip_route_common
 from click.testing import CliRunner
 import mock
+import sys
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
+
+sys.path.insert(0, test_path)
 
 
 class TestShowIpRouteCommands(object):

--- a/tests/vlan_test.py
+++ b/tests/vlan_test.py
@@ -8,6 +8,7 @@ import config.main as config
 import show.main as show
 from utilities_common.db import Db
 from importlib import reload
+import utilities_common.bgp_util as bgp_util
 
 show_vlan_brief_output="""\
 +-----------+-----------------+-----------------+----------------+-------------+
@@ -143,15 +144,22 @@ config_add_del_vlan_and_vlan_member_in_alias_mode_output="""\
 +-----------+-----------------+-----------------+----------------+-------------+
 """
 class TestVlan(object):
+    _old_run_bgp_command = None
     @classmethod
     def setup_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "1"
         # ensure that we are working with single asic config
+        cls._old_run_bgp_command = bgp_util.run_bgp_command
+        bgp_util.run_bgp_command = mock.MagicMock(
+            return_value=cls.mock_run_bgp_command())
         from .mock_tables import dbconnector
         from .mock_tables import mock_single_asic
         reload(mock_single_asic)
         dbconnector.load_namespace_config()
         print("SETUP")
+
+    def mock_run_bgp_command():
+        return ""
 
     def test_show_vlan(self):
         runner = CliRunner()
@@ -579,4 +587,5 @@ class TestVlan(object):
     @classmethod
     def teardown_class(cls):
         os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        bgp_util.run_bgp_command = cls._old_run_bgp_command
         print("TEARDOWN")

--- a/utilities_common/bgp_util.py
+++ b/utilities_common/bgp_util.py
@@ -185,7 +185,7 @@ def run_bgp_command(vtysh_cmd, bgp_namespace=multi_asic.DEFAULT_NAMESPACE, vtysh
     cmd = 'sudo {} {} -c "{}"'.format(
         vtysh_shell_cmd, bgp_instance_id, vtysh_cmd)
     try:
-        output = clicommon.run_command(cmd, return_cmd=True)
+        output = clicommon.run_command(cmd)
     except Exception:
         ctx = click.get_current_context()
         ctx.fail("Unable to get summary from bgp {}".format(bgp_instance_id))


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix show route return command to return error code on failure cases. The parameter return_cmd=True in run_command will suppress the return code and return success even in error scenarios.

#### How I did it
Removed return_cmd=True from the run_command.

#### How to verify it
Added UT to verify it

#### Previous command output (if the output of a command-line utility has changed)

```
root@sonic:/home/admin# show ip route 123
% Unknown command: show ip route 123 

root@sonic:/home/admin# echo $?
0

```

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show ip route 123
% Unknown command: show ip route 123 

root@sonic:/home/admin# echo $?
1

```
