### PR TITLE
[DPB]Fixing typo in config breakout output

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -224,8 +224,8 @@ def breakout_Ports(cm, delPorts=list(), portJson=dict(), force=False, \
     # check if DPB failed
     if ret == False:
         if not force and deps:
-            click.echo("Dependecies Exist. No further action will be taken")
-            click.echo("*** Printing dependecies ***")
+            click.echo("Dependencies Exist. No further action will be taken")
+            click.echo("*** Printing dependencies ***")
             for dep in deps:
                 click.echo(dep)
             sys.exit(0)

--- a/tests/config_dpb_test.py
+++ b/tests/config_dpb_test.py
@@ -397,7 +397,7 @@ class TestConfigDPB(object):
 
         print(result.exit_code, result.output)
         assert result.exit_code == 0
-        assert 'Dependecies Exist.' in result.output
+        assert 'Dependencies Exist.' in result.output
 
         # verbose must be set while creating instance of ConfigMgmt class
         calls = [mock.call(True)]
@@ -539,8 +539,8 @@ class TestConfigDPB(object):
 
             print(result.exit_code, result.output)
             assert result.exit_code == 0
-            assert 'Dependecies Exist.' in result.output
-            assert 'Printing dependecies' in result.output
+            assert 'Dependencies Exist.' in result.output
+            assert 'Printing dependencies' in result.output
             assert 'NO-NSW-PACL-V4' in result.output
 
             brk_cfg_table = db.cfgdb.get_table('BREAKOUT_CFG')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed typo in config breakout output. Fixed dependecies to dependencies
#### How I did it
Fixed typo

#### How to verify it
Modified UT to align

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

