### PR TITLE
[portconfig]Auto FEC initial changes

### DIFF
--- a/tests/config_an_test.py
+++ b/tests/config_an_test.py
@@ -110,7 +110,7 @@ class TestConfigInterface(object):
         assert "fec fc is not in ['rs', 'none', 'test']" in result.output
         # Negative case: set a fec mode which is not default on an interface without supported_fecs
         result = self.basic_check("fec", ["Ethernet4", "test"], ctx, operator.ne)
-        assert "fec test is not in ['rs', 'fc', 'none']" in result.output
+        assert "fec test is not in ['rs', 'fc', 'none', 'auto']" in result.output
         # Negative case: set a fec mode on a port where setting fec is not supported
         result = self.basic_check("fec", ["Ethernet112", "test"], ctx, operator.ne)
         assert "Setting fec is not supported" in result.output

--- a/utilities_common/constants.py
+++ b/utilities_common/constants.py
@@ -1,7 +1,7 @@
 #All the constant used in sonic-utilities
 
 DEFAULT_NAMESPACE = ''
-DEFAULT_SUPPORTED_FECS_LIST = [ 'rs', 'fc', 'none']
+DEFAULT_SUPPORTED_FECS_LIST = [ 'rs', 'fc', 'none', 'auto']
 DISPLAY_ALL = 'all'
 DISPLAY_EXTERNAL = 'frontend'
 BGP_NEIGH_OBJ = 'BGP_NEIGH'


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Initial changes for auto FEC

#### How I did it
Added default option of auto for FEC

#### How to verify it
Modified UT to verify

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

