### PR TITLE
[ipintutil]Handle exception in show ip interfaces command

### DIFF
--- a/scripts/ipintutil
+++ b/scripts/ipintutil
@@ -150,7 +150,10 @@ def get_ip_intfs_in_namespace(af, namespace, display):
         ip_intf_attr = []
         if namespace != constants.DEFAULT_NAMESPACE and skip_ip_intf_display(iface, display):
             continue
-        ipaddresses = multi_asic_util.multi_asic_get_ip_intf_addr_from_ns(namespace, iface)
+        try:
+            ipaddresses = multi_asic_util.multi_asic_get_ip_intf_addr_from_ns(namespace, iface)
+        except ValueError:
+            continue
         if af in ipaddresses:
             ifaddresses = []
             bgp_neighs = {}


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Handle exception in show ip interfaces command when executed during config reload. Sometimes during config reload the interfaces are removed and if show ip interfaces was executed during this time we may get the below traceback. The interface would exist when the call multi_asic_get_ip_intf_from_ns was made but would have been removed in the subsequent for loop which tries to get ip interface data for each interface

```
show ip interfaces

Traceback (most recent call last):
  File "/usr/local/bin/ipintutil", line 276, in

     main()
  File "/usr/local/bin/ipintutil", line 269, in main
    ip_intfs = get_ip_intfs(af, namespace, display)
  File "/usr/local/bin/ipintutil", line 232, in get_ip_intfs
    ip_intfs_in_ns = get_ip_intfs_in_namespace(af, namespace, display)
  File "/usr/local/bin/ipintutil", line 153, in get_ip_intfs_in_namespace
    ipaddresses = multi_asic_util.multi_asic_get_ip_intf_addr_from_ns(namespace, iface)
  File "/usr/local/lib/python3.9/dist-packages/utilities_common/multi_asic.py", line 186, in multi_asic_get_ip_intf_addr_from_ns

     ipaddresses = netifaces.ifaddresses(iface)
ValueError: You must specify a valid interface name.

```


#### How I did it
Adding try exception block so that if an interface is not present, it would be skipped.

#### How to verify it
Running show ip interface command and performing config reload in parallel

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

