### PR TITLE
[Mellanox]Fix Syntax Warning in config mlnx command

### DIFF
--- a/config/plugins/mlnx.py
+++ b/config/plugins/mlnx.py
@@ -216,7 +216,7 @@ def sdk_sniffer_enable():
                                       env_variable_string=sdk_sniffer_env_variable_string)
     if not ignore:
         err = restart_swss()
-        if err is not 0:
+        if err != 0:
             return
         click.echo('SDK sniffer is Enabled, recording file is %s.' % sdk_sniffer_filename)
     else:
@@ -229,7 +229,7 @@ def sdk_sniffer_disable():
     ignore = sniffer_env_variable_set(enable=False, env_variable_name=ENV_VARIABLE_SX_SNIFFER)
     if not ignore:
         err = restart_swss()
-        if err is not 0:
+        if err != 0:
             return
         click.echo("SDK sniffer is Disabled.")
     else:

--- a/tests/config_mlnx_test.py
+++ b/tests/config_mlnx_test.py
@@ -1,0 +1,47 @@
+import sys
+import click
+import pytest
+import config.plugins.mlnx as config
+from unittest.mock import patch, Mock
+from click.testing import CliRunner
+from utilities_common.db import Db
+
+
+@patch('config.plugins.mlnx.sniffer_env_variable_set', Mock(return_value=False))
+@patch('config.plugins.mlnx.sniffer_filename_generate', Mock(return_value="sdk_file_name"))
+class TestConfigMlnx(object):
+    def setup(self):
+        print('SETUP')
+
+
+    @patch('config.plugins.mlnx.restart_swss', Mock(return_value=0))
+    def test_config_sniffer_enable(self):
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.mlnx.commands["sniffer"].commands["sdk"].commands["enable"],["-y"])
+        assert "SDK sniffer is Enabled, recording file is sdk_file_name." in result.output
+
+    @patch('config.plugins.mlnx.restart_swss', Mock(return_value=0))
+    def test_config_sniffer_disble(self):
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.mlnx.commands["sniffer"].commands["sdk"].commands["disable"],["-y"])
+        assert "SDK sniffer is Disabled." in result.output
+
+    @patch('config.plugins.mlnx.restart_swss', Mock(return_value=1))
+    def test_config_sniffer_enable_fail(self):
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.mlnx.commands["sniffer"].commands["sdk"].commands["enable"],["-y"])
+        assert "SDK sniffer is Enabled, recording file is sdk_file_name." not in result.output
+
+    @patch('config.plugins.mlnx.restart_swss', Mock(return_value=1))
+    def test_config_sniffer_disble_fail(self):
+        db = Db()
+        runner = CliRunner()
+        result = runner.invoke(config.mlnx.commands["sniffer"].commands["sdk"].commands["disable"],["-y"])
+        assert "SDK sniffer is Disabled." not in result.output
+
+    def teardown(self):
+        print('TEARDOWN')
+


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix syntax warnings when config platform mlnx command is executed
```
dmin@sonic:~$ sudo config /usr/local/lib/python3.11/dist-packages/config/aaa.py:120: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(auth_protocol) is 0:
/usr/local/lib/python3.11/dist-packages/config/plugins/mlnx.py:219: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if err is not 0:
/usr/local/lib/python3.11/dist-packages/config/plugins/mlnx.py:232: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if err is not 0:
/usr/local/lib/python3.11/dist-packages/config/aaa.py:120: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(auth_protocol) is 0:
/usr/local/lib/python3.11/dist-packages/config/plugins/mlnx.py:219: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if err is not 0:
/usr/local/lib/python3.11/dist-packages/config/plugins/mlnx.py:232: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if err is not 0:
```
#### How I did it

Replaced is not with !=

#### How to verify it
Run the command as well as added UT

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

