### PR TITLE
[subintf]Fix the interface name length validation for subinterface

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -8723,7 +8723,7 @@ def add_subinterface(ctx, subinterface_name, vid):
 
         if interface_alias is None:
             ctx.fail("{} invalid subinterface".format(interface_alias))
-        if not isInterfaceNameValid(interface_alias):
+        if not isInterfaceNameValid(subinterface_name):
             ctx.fail("Subinterface name length should not exceed {} characters".format(IFACE_NAME_MAX_LEN))
 
         if interface_alias.startswith("Po") is True:

--- a/tests/subintf_test.py
+++ b/tests/subintf_test.py
@@ -87,6 +87,12 @@ class TestSubinterface(object):
         assert result.exit_code != 0
         assert ('Eth0.1002') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
+        #Check if interface name length doesn't exceed 15 characters
+        result = runner.invoke(config.config.commands["subinterface"].commands["add"], ["Ethernet0.000002", "2"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert "Error: Subinterface name length should not exceed 15 characters" in result.output
+        assert ('Ethernet0.000002') not in db.cfgdb.get_table('VLAN_SUB_INTERFACE')
 
     def test_delete_non_existing_subintf(self):
         runner = CliRunner()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Subinterface name length validation validates only the interface alias and not the entire subinterface name. This will result in wrong validation.

#### How I did it
Fixed the validation to use subinterface name and not just interface alias.

#### How to verify it
Added test case to verify.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

